### PR TITLE
KP-11146 Add support for listing annotators for each language

### DIFF
--- a/mink/core/jobs.py
+++ b/mink/core/jobs.py
@@ -606,11 +606,11 @@ class DefaultJob():
         sparv_command = f"{app.config.get('SPARV_COMMAND')} modules --annotators --json"
         p = utils.ssh_run(f"cd {shlex.quote(all_lang_dir)} && {sparv_env} {sparv_command}")
 
+        stdout = p.stdout.decode() if p.stdout else ""
         if p.returncode != 0:
             stderr = p.stderr.decode() if p.stderr else ""
-            raise exceptions.JobError(f"Failed to run Sparv! {stderr}")
+            raise exceptions.JobError(f"Failed to run Sparv! stderr={stderr!r} stdout={stdout!r}")
 
-        stdout = p.stdout.decode() if p.stdout else "{}"
         json_start = stdout.find("{")
         if json_start == -1:
             return {}

--- a/mink/core/jobs.py
+++ b/mink/core/jobs.py
@@ -582,28 +582,26 @@ class DefaultJob():
         return languages
 
     def list_annotators(self):
-        """List annotators available in Sparv, using Swedish as the seed language.
+        """List annotators available in Sparv for this job's language.
 
-        Runs 'sparv modules --annotators --json' in the Swedish temp corpus dir. Each
-        annotator function includes a 'language' list covering all languages it supports,
-        so the caller can filter the result for any language. Result is cached in memcached.
+        Runs 'sparv modules --annotators --json' in the language's temp corpus dir.
+        Result is cached in memcached per language.
         """
         from flask import g  # noqa: PLC0415
 
-        cached = g.cache.get_annotators()
+        cached = g.cache.get_annotators(self.lang)
         if cached is not None:
             return cached
 
-        swe_dir = str(sparv_utils.get_corpus_dir("swe", default_dir=True))
-        p = utils.ssh_run(f"mkdir -p {shlex.quote(swe_dir)} && "
-                          f"echo 'metadata:\n  language: swe' > "
-                          f"{shlex.quote(swe_dir + '/' + self.config_file)}")
+        p = utils.ssh_run(f"mkdir -p {shlex.quote(self.remote_corpus_dir)} && "
+                          f"echo 'metadata:\n  language: {self.lang}' > "
+                          f"{shlex.quote(self.remote_corpus_dir + '/' + self.config_file)}")
         if p.stderr:
             raise Exception(f"Failed to list annotators! {p.stderr.decode()}")
 
         sparv_env = app.config.get("SPARV_ENVIRON")
         sparv_command = f"{app.config.get('SPARV_COMMAND')} modules --annotators --json"
-        p = utils.ssh_run(f"cd {shlex.quote(swe_dir)} && {sparv_env} {sparv_command}")
+        p = utils.ssh_run(f"cd {shlex.quote(self.remote_corpus_dir)} && {sparv_env} {sparv_command}")
 
         stdout = p.stdout.decode() if p.stdout else ""
         if p.returncode != 0:
@@ -614,7 +612,7 @@ class DefaultJob():
         if json_start == -1:
             return {}
         data = json.loads(stdout[json_start:]).get("annotators", {})
-        g.cache.set_annotators(data)
+        g.cache.set_annotators(self.lang, data)
         return data
 
     def list_exports(self):

--- a/mink/core/jobs.py
+++ b/mink/core/jobs.py
@@ -542,9 +542,6 @@ class Job():
         return True, sparv_output
 
 
-_annotators_cache = None
-
-
 class DefaultJob():
     """A default job item for running generic Sparv commands like `sparv run -l`."""
 
@@ -585,26 +582,28 @@ class DefaultJob():
         return languages
 
     def list_annotators(self):
-        """List all available annotators across all languages.
+        """List annotators available in Sparv, using Swedish as the seed language.
 
-        Uses 'language: __all__' in the corpus config to bypass per-language filtering,
-        returning every annotator Sparv knows about along with the languages each supports.
-        The result is cached globally since it doesn't depend on corpus language.
+        Runs 'sparv modules --annotators --json' in the Swedish temp corpus dir. Each
+        annotator function includes a 'language' list covering all languages it supports,
+        so the caller can filter the result for any language. Result is cached in memcached.
         """
-        global _annotators_cache
-        if _annotators_cache is not None:
-            return _annotators_cache
+        from flask import g  # noqa: PLC0415
 
-        all_lang_dir = str(sparv_utils.get_corpus_dir("__all__", default_dir=True))
-        config_path = all_lang_dir + "/" + self.config_file
-        p = utils.ssh_run(f"mkdir -p {shlex.quote(all_lang_dir)} && "
-                          f"echo 'metadata:\n  language: __all__' > {shlex.quote(config_path)}")
+        cached = g.cache.get_annotators()
+        if cached is not None:
+            return cached
+
+        swe_dir = str(sparv_utils.get_corpus_dir("swe", default_dir=True))
+        p = utils.ssh_run(f"mkdir -p {shlex.quote(swe_dir)} && "
+                          f"echo 'metadata:\n  language: swe' > "
+                          f"{shlex.quote(swe_dir + '/' + self.config_file)}")
         if p.stderr:
             raise Exception(f"Failed to list annotators! {p.stderr.decode()}")
 
         sparv_env = app.config.get("SPARV_ENVIRON")
         sparv_command = f"{app.config.get('SPARV_COMMAND')} modules --annotators --json"
-        p = utils.ssh_run(f"cd {shlex.quote(all_lang_dir)} && {sparv_env} {sparv_command}")
+        p = utils.ssh_run(f"cd {shlex.quote(swe_dir)} && {sparv_env} {sparv_command}")
 
         stdout = p.stdout.decode() if p.stdout else ""
         if p.returncode != 0:
@@ -615,7 +614,7 @@ class DefaultJob():
         if json_start == -1:
             return {}
         data = json.loads(stdout[json_start:]).get("annotators", {})
-        _annotators_cache = data
+        g.cache.set_annotators(data)
         return data
 
     def list_exports(self):

--- a/mink/core/jobs.py
+++ b/mink/core/jobs.py
@@ -554,8 +554,13 @@ class DefaultJob():
         self.config_file = app.config.get("SPARV_CORPUS_CONFIG")
 
     def list_languages(self):
-        """List the languages available in Sparv."""
-        # Create and corpus dir with config file on Sparv server
+        """List the languages available in Sparv. Result is cached in memcached."""
+        from flask import g  # noqa: PLC0415
+
+        cached = g.cache.get_languages()
+        if cached is not None:
+            return cached
+
         p = utils.ssh_run(f"mkdir -p {shlex.quote(self.remote_corpus_dir)} && "
                           f"echo 'metadata:\n  language: {self.lang}' > "
                           f"{shlex.quote(self.remote_corpus_dir + '/' + self.config_file)}")
@@ -579,40 +584,48 @@ class DefaultJob():
             matchobj = re.match(r"(.+?)\s+(\S+)$", line)
             if matchobj:
                 languages.append({"name": matchobj.group(1), "code": matchobj.group(2)})
+        g.cache.set_languages(languages)
         return languages
 
     def list_annotators(self):
-        """List annotators available in Sparv for this job's language.
+        """List all annotators available in Sparv.
 
-        Runs 'sparv modules --annotators --json' in the language's temp corpus dir.
-        Result is cached in memcached per language.
+        Uses a seed language that activates all relevant annotator modules. Each
+        annotator function carries a 'language' list, so callers can filter per
+        language without needing a separate SSH call per language.
+        Result is cached in memcached.
         """
         from flask import g  # noqa: PLC0415
 
-        cached = g.cache.get_annotators(self.lang)
+        cached = g.cache.get_annotators()
         if cached is not None:
             return cached
 
-        p = utils.ssh_run(f"mkdir -p {shlex.quote(self.remote_corpus_dir)} && "
-                          f"echo 'metadata:\n  language: {self.lang}' > "
-                          f"{shlex.quote(self.remote_corpus_dir + '/' + self.config_file)}")
-        if p.stderr:
-            raise Exception(f"Failed to list annotators! {p.stderr.decode()}")
-
+        seed_langs = app.config.get("SPARV_ANNOTATOR_SEED_LANGUAGES", ["fin"])
         sparv_env = app.config.get("SPARV_ENVIRON")
         sparv_command = f"{app.config.get('SPARV_COMMAND')} modules --annotators --json"
-        p = utils.ssh_run(f"cd {shlex.quote(self.remote_corpus_dir)} && {sparv_env} {sparv_command}")
 
-        stdout = p.stdout.decode() if p.stdout else ""
-        if p.returncode != 0:
-            stderr = p.stderr.decode() if p.stderr else ""
-            raise exceptions.JobError(f"Failed to run Sparv! stderr={stderr!r} stdout={stdout!r}")
+        data = {}
+        for seed_lang in seed_langs:
+            seed_dir = str(sparv_utils.get_corpus_dir(seed_lang, default_dir=True))
+            p = utils.ssh_run(f"mkdir -p {shlex.quote(seed_dir)} && "
+                              f"echo 'metadata:\n  language: {seed_lang}' > "
+                              f"{shlex.quote(seed_dir + '/' + self.config_file)}")
+            if p.stderr:
+                raise Exception(f"Failed to list annotators for seed '{seed_lang}'! {p.stderr.decode()}")
 
-        json_start = stdout.find("{")
-        if json_start == -1:
-            return {}
-        data = json.loads(stdout[json_start:]).get("annotators", {})
-        g.cache.set_annotators(self.lang, data)
+            p = utils.ssh_run(f"cd {shlex.quote(seed_dir)} && {sparv_env} {sparv_command}")
+            stdout = p.stdout.decode() if p.stdout else ""
+            if p.returncode != 0:
+                stderr = p.stderr.decode() if p.stderr else ""
+                raise exceptions.JobError(f"Failed to run Sparv for seed '{seed_lang}'! "
+                                          f"stderr={stderr!r} stdout={stdout!r}")
+
+            json_start = stdout.find("{")
+            if json_start != -1:
+                data.update(json.loads(stdout[json_start:]).get("annotators", {}))
+
+        g.cache.set_annotators(data)
         return data
 
     def list_exports(self):

--- a/mink/core/jobs.py
+++ b/mink/core/jobs.py
@@ -542,6 +542,9 @@ class Job():
         return True, sparv_output
 
 
+_annotators_cache = None
+
+
 class DefaultJob():
     """A default job item for running generic Sparv commands like `sparv run -l`."""
 
@@ -580,6 +583,40 @@ class DefaultJob():
             if matchobj:
                 languages.append({"name": matchobj.group(1), "code": matchobj.group(2)})
         return languages
+
+    def list_annotators(self):
+        """List all available annotators across all languages.
+
+        Uses 'language: __all__' in the corpus config to bypass per-language filtering,
+        returning every annotator Sparv knows about along with the languages each supports.
+        The result is cached globally since it doesn't depend on corpus language.
+        """
+        global _annotators_cache
+        if _annotators_cache is not None:
+            return _annotators_cache
+
+        all_lang_dir = str(sparv_utils.get_corpus_dir("__all__", default_dir=True))
+        config_path = all_lang_dir + "/" + self.config_file
+        p = utils.ssh_run(f"mkdir -p {shlex.quote(all_lang_dir)} && "
+                          f"echo 'metadata:\n  language: __all__' > {shlex.quote(config_path)}")
+        if p.stderr:
+            raise Exception(f"Failed to list annotators! {p.stderr.decode()}")
+
+        sparv_env = app.config.get("SPARV_ENVIRON")
+        sparv_command = f"{app.config.get('SPARV_COMMAND')} modules --annotators --json"
+        p = utils.ssh_run(f"cd {shlex.quote(all_lang_dir)} && {sparv_env} {sparv_command}")
+
+        if p.returncode != 0:
+            stderr = p.stderr.decode() if p.stderr else ""
+            raise exceptions.JobError(f"Failed to run Sparv! {stderr}")
+
+        stdout = p.stdout.decode() if p.stdout else "{}"
+        json_start = stdout.find("{")
+        if json_start == -1:
+            return {}
+        data = json.loads(stdout[json_start:]).get("annotators", {})
+        _annotators_cache = data
+        return data
 
     def list_exports(self):
         """List the available exports for the current language."""

--- a/mink/core/utils.py
+++ b/mink/core/utils.py
@@ -167,8 +167,20 @@ def standardize_config(config, corpus_id):
     # Make corpus protected and add Korp config directory
     config_yaml["korp"] = {
         "protected": True,
-        "modes": [{"name": "mink"}]
+        "modes": [{"name": "mink"}],
+        # Include all annotations even if they lack a Korp preset file on the server
+        "keep_undefined_annotations": True,
     }
+
+    # Enable dependency tree visualization if dep parse annotations are present
+    export_annotations = config_yaml.get("export", {}).get("annotations", [])
+    has_dephead = any("dephead" in str(a) for a in export_annotations)
+    has_deprel = any("deprel" in str(a) for a in export_annotations)
+    if has_dephead and has_deprel:
+        config_yaml["korp"]["deptree"] = {
+            "head_attr": "dephead",
+            "rel_attr": "deprel",
+        }
     if app.config.get("KORP_REMOTE_HOST"):
         config_yaml["korp"]["remote_host"] = app.config.get("KORP_REMOTE_HOST")
     if app.config.get("KORP_CONFIG_DIR"):

--- a/mink/memcached/cache.py
+++ b/mink/memcached/cache.py
@@ -110,3 +110,14 @@ class Cache():
             self.client.delete(job)
         else:
             del g.resource_dict[job]
+
+    def get_annotators(self):
+        """Get cached Sparv annotator info from memcached, or None if unavailable."""
+        if self.client is not None:
+            return self.client.get("sparv_annotators")
+        return None
+
+    def set_annotators(self, value):
+        """Store Sparv annotator info in memcached."""
+        if self.client is not None:
+            self.client.set("sparv_annotators", value)

--- a/mink/memcached/cache.py
+++ b/mink/memcached/cache.py
@@ -111,13 +111,13 @@ class Cache():
         else:
             del g.resource_dict[job]
 
-    def get_annotators(self):
-        """Get cached Sparv annotator info from memcached, or None if unavailable."""
+    def get_annotators(self, language):
+        """Get cached Sparv annotator info for a language from memcached, or None if unavailable."""
         if self.client is not None:
-            return self.client.get("sparv_annotators")
+            return self.client.get(f"sparv_annotators_{language}")
         return None
 
-    def set_annotators(self, value):
-        """Store Sparv annotator info in memcached."""
+    def set_annotators(self, language, value):
+        """Store Sparv annotator info for a language in memcached."""
         if self.client is not None:
-            self.client.set("sparv_annotators", value)
+            self.client.set(f"sparv_annotators_{language}", value)

--- a/mink/memcached/cache.py
+++ b/mink/memcached/cache.py
@@ -111,13 +111,24 @@ class Cache():
         else:
             del g.resource_dict[job]
 
-    def get_annotators(self, language):
-        """Get cached Sparv annotator info for a language from memcached, or None if unavailable."""
+    def get_languages(self):
+        """Get cached Sparv language list from memcached, or None if unavailable."""
         if self.client is not None:
-            return self.client.get(f"sparv_annotators_{language}")
+            return self.client.get("sparv_languages")
         return None
 
-    def set_annotators(self, language, value):
-        """Store Sparv annotator info for a language in memcached."""
+    def set_languages(self, value):
+        """Store Sparv language list in memcached."""
         if self.client is not None:
-            self.client.set(f"sparv_annotators_{language}", value)
+            self.client.set("sparv_languages", value)
+
+    def get_annotators(self):
+        """Get cached Sparv annotator info from memcached, or None if unavailable."""
+        if self.client is not None:
+            return self.client.get("sparv_annotators")
+        return None
+
+    def set_annotators(self, value):
+        """Store Sparv annotator info in memcached."""
+        if self.client is not None:
+            self.client.set("sparv_annotators", value)

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -380,19 +380,18 @@ def sparv_languages():
                               return_code="failed_listing_languages"), 500
 
     if include_annotators:
+        try:
+            all_annotators = job.list_annotators()
+        except Exception as e:
+            return utils.response("Failed listing annotators", err=True, info=str(e),
+                                  return_code="failed_listing_annotators"), 500
         for lang in languages:
-            try:
-                lang_job = jobs.DefaultJob(language=lang["code"])
-                all_annotators = lang_job.list_annotators()
-            except Exception as e:
-                return utils.response("Failed listing annotators", err=True, info=str(e),
-                                      return_code="failed_listing_annotators"), 500
-            # Keep only modules with at least one language-specific function,
-            # and return just the module name and description.
+            code = lang["code"]
+            # Keep only modules that explicitly declare support for this language.
             lang["annotators"] = {
                 module: info.get("description", "")
                 for module, info in all_annotators.items()
-                if any(f.get("language") for f in info.get("functions", {}).values())
+                if any(code in (f.get("language") or []) for f in info.get("functions", {}).values())
             }
 
     return utils.response("Listing languages available in Sparv", languages=languages,

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -383,10 +383,17 @@ def sparv_languages():
         for lang in languages:
             try:
                 lang_job = jobs.DefaultJob(language=lang["code"])
-                lang["annotators"] = lang_job.list_annotators()
+                all_annotators = lang_job.list_annotators()
             except Exception as e:
                 return utils.response("Failed listing annotators", err=True, info=str(e),
                                       return_code="failed_listing_annotators"), 500
+            # Keep only modules with at least one language-specific function,
+            # and return just the module name and description.
+            lang["annotators"] = {
+                module: info.get("description", "")
+                for module, info in all_annotators.items()
+                if any(f.get("language") for f in info.get("functions", {}).values())
+            }
 
     return utils.response("Listing languages available in Sparv", languages=languages,
                           return_code="listing_languages")

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -387,12 +387,23 @@ def sparv_languages():
                                   return_code="failed_listing_annotators"), 500
         for lang in languages:
             code = lang["code"]
-            # Keep only modules that explicitly declare support for this language.
-            lang["annotators"] = {
-                module: info.get("description", "")
-                for module, info in all_annotators.items()
-                if any(code in (f.get("language") or []) for f in info.get("functions", {}).values())
-            }
+            lang["annotators"] = {}
+            for module, info in all_annotators.items():
+                # Collect annotations from functions that explicitly support this language.
+                annotations = {}
+                for f_info in info.get("functions", {}).values():
+                    if code not in (f_info.get("language") or []):
+                        continue
+                    for ann_name, ann_info in f_info.get("annotations", {}).items():
+                        entry = {"description": ann_info.get("description", "")}
+                        if cls := ann_info.get("class"):
+                            entry["class"] = cls
+                        annotations[ann_name] = entry
+                if annotations:
+                    lang["annotators"][module] = {
+                        "description": info.get("description", ""),
+                        "annotations": annotations,
+                    }
 
     return utils.response("Listing languages available in Sparv", languages=languages,
                           return_code="listing_languages")

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -366,13 +366,33 @@ def make_status_response(info, admin=False):
 
 @bp.route("/sparv-languages", methods=["GET"])
 def sparv_languages():
-    """List languages available in Sparv."""
+    """List languages available in Sparv.
+
+    Optional query parameter:
+    - annotators=true: include per-language annotator information in the response.
+    """
+    include_annotators = (request.args.get("annotators") or "").lower() == "true"
     try:
         job = jobs.DefaultJob()
         languages = job.list_languages()
     except Exception as e:
         return utils.response("Failed listing languages", err=True, info=str(e),
                               return_code="failed_listing_languages"), 500
+
+    if include_annotators:
+        try:
+            all_annotators = job.list_annotators()
+        except Exception as e:
+            return utils.response("Failed listing annotators", err=True, info=str(e),
+                                  return_code="failed_listing_annotators"), 500
+        for lang in languages:
+            code = lang["code"]
+            lang["annotators"] = {
+                module: info
+                for module, info in all_annotators.items()
+                if any(code in (f.get("language") or []) for f in info.get("functions", {}).values())
+            }
+
     return utils.response("Listing languages available in Sparv", languages=languages,
                           return_code="listing_languages")
 

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -380,18 +380,13 @@ def sparv_languages():
                               return_code="failed_listing_languages"), 500
 
     if include_annotators:
-        try:
-            all_annotators = job.list_annotators()
-        except Exception as e:
-            return utils.response("Failed listing annotators", err=True, info=str(e),
-                                  return_code="failed_listing_annotators"), 500
         for lang in languages:
-            code = lang["code"]
-            lang["annotators"] = {
-                module: info
-                for module, info in all_annotators.items()
-                if any(code in (f.get("language") or []) for f in info.get("functions", {}).values())
-            }
+            try:
+                lang_job = jobs.DefaultJob(language=lang["code"])
+                lang["annotators"] = lang_job.list_annotators()
+            except Exception as e:
+                return utils.response("Failed listing annotators", err=True, info=str(e),
+                                      return_code="failed_listing_annotators"), 500
 
     return utils.response("Listing languages available in Sparv", languages=languages,
                           return_code="listing_languages")


### PR DESCRIPTION
We want the frontend to be able to tell which annotators are available for a given language. To that end, this exposes functionality in sparv for doing that, and adds a ?annotators=true option to /sparv-languages. This also requires choosing some "seed languages" for which we query available modules (which also tell us what languages they support), and the modules discovered that way becomes the basis of what languages we support.